### PR TITLE
Add Check for User Permissions, Bump Discord4j to 3.2.1, Ignore Missing Commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.discord4j</groupId>
       <artifactId>discord4j-core</artifactId>
-      <version>3.2.0</version>
+      <version>3.2.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
@@ -18,12 +18,12 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
         Mono<Boolean> botPermsMono = gcMono                 // mono for checking if the bot has perms for this cmd
                 .flatMap(gc -> gc.getEffectivePermissions(event.getClient().getSelfId()))
                 .map(perms -> perms.containsAll(baseCommand.getBotPermissions()))
-                .switchIfEmpty(Mono.just(false));
+                .defaultIfEmpty(false);
 
         Mono<Boolean> userPermsMono = gcMono                // mono for checking if the user has perms for this cmd
                 .flatMap(gc -> gc.getEffectivePermissions(event.getInteraction().getUser().getId()))
                 .map(perms -> perms.containsAll(baseCommand.getUserDiscordPermissions()))
-                .switchIfEmpty(Mono.just(false));
+                .defaultIfEmpty(false);
 
         return botPermsMono.zipWith(userPermsMono)         // check both simultaneously to produce error messages
                 .flatMap(havePermsTuple -> Mono.defer(() -> {

--- a/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
@@ -6,31 +6,55 @@ import discord4j.core.event.domain.interaction.InteractionCreateEvent;
 import discord4j.core.event.domain.interaction.MessageInteractionEvent;
 import discord4j.core.event.domain.interaction.UserInteractionEvent;
 import discord4j.core.object.entity.channel.GuildChannel;
+import discord4j.rest.util.PermissionSet;
 import net.exploitables.slashlib.commands.BaseCommand;
 import net.exploitables.slashlib.context.*;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 public class InteractionEventReceiverImpl implements InteractionEventReceiver {
     private <E extends InteractionCreateEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
-        return event.getInteraction()
-            .getChannel()
-            .ofType(GuildChannel.class)
-            .flatMap(gc -> gc.getEffectivePermissions(event.getClient().getSelfId()))
-            .map(perms -> perms.containsAll(baseCommand.getBotPermissions()))
-            .switchIfEmpty(Mono.just(false))
-            .filter(havePerms -> havePerms || baseCommand.isUsableInDMs())
-            // No perms and not usable in DMs, send silent error message
-            .switchIfEmpty(Mono.defer(() -> {
-                String content;
-                if (!baseCommand.getBotPermissions().isEmpty()) {
-                    content = "I need the following permissions for that command: " +
-                            baseCommand.getBotPermissions().asEnumSet();
-                } else {
-                    content = "That is not usable in DMs.";
-                }
-                // .then(Mono.empty()) for type compatibility
-                return event.reply(content).withEphemeral(true).then(Mono.empty());
-            }));
+        Mono<GuildChannel> gcMono = event.getInteraction()   // mono for getting the guild channel where the
+            .getChannel()                                    // interaction occurred
+            .ofType(GuildChannel.class);
+
+        Mono<Boolean> botPermsMono = gcMono                 // mono for checking if the bot has perms for this cmd
+                .flatMap(gc -> gc.getEffectivePermissions(event.getClient().getSelfId()))
+                .map(perms -> perms.containsAll(baseCommand.getBotPermissions()))
+                .switchIfEmpty(Mono.just(false));
+
+        Mono<Boolean> userPermsMono = gcMono                // mono for checking if the user has perms for this cmd
+                .flatMap(gc -> gc.getEffectivePermissions(event.getInteraction().getUser().getId()))
+                .map(perms -> perms.containsAll(baseCommand.getUserDiscordPermissions()))
+                .switchIfEmpty(Mono.just(false));
+
+        return botPermsMono.zipWith(userPermsMono)         // check both simultaneously to produce error messages
+                .flatMap(havePermsTuple -> Mono.defer(() -> {
+                    String content;
+                    boolean botHasPerms = havePermsTuple.getT1();
+                    boolean userHasDiscordPerms = havePermsTuple.getT2();
+                    boolean condition = (botHasPerms && userHasDiscordPerms) || baseCommand.isUsableInDMs();
+                    if (!condition) {  // No perms and not usable in DMs, send silent error message
+                        if (
+                                !baseCommand.getBotPermissions().isEmpty()
+                                || !baseCommand.getUserDiscordPermissions().isEmpty()
+                        ) {
+                            if (!botHasPerms) {
+                                content = "I need the following permissions for that command: " +
+                                        baseCommand.getBotPermissions().asEnumSet();
+                            } else {
+                                content = "You need to have the following permissions to use that command: " +
+                                        baseCommand.getUserDiscordPermissions().asEnumSet();
+                            }
+                        } else {
+                            content = "That is not usable in DMs.";
+                        }
+                        // .then(Mono.empty()) for type compatibility
+                        return event.reply(content).withEphemeral(true).then(Mono.empty());
+                    } else {
+                        return Mono.just(true);
+                    }
+                }));
     }
 
     @Override
@@ -55,7 +79,7 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
     public Mono<UserInteractionContext> receiveUserInteractionEvent(UserInteractionEvent event) {
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(SlashLib.get().getCommandRegister().getCommandStructure().getUserCommands().get(event.getCommandName()))
-            // Check bot permissions in guild
+            // Check bot and user permissions in guild
             .flatMap(userCommand -> checkPermissions(event, userCommand)
                 // Have perms, create the builder and collect data
                 .flatMap(_bool -> userCommand.setRequestData(new UserInteractionContextBuilder(event))
@@ -70,7 +94,7 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
     public Mono<MessageInteractionContext> receiveMessageInteractionEvent(MessageInteractionEvent event) {
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(SlashLib.get().getCommandRegister().getCommandStructure().getMessageCommands().get(event.getCommandName()))
-            // Check bot permissions in guild
+            // Check bot and user permissions in guild
             .flatMap(messageCommand -> checkPermissions(event, messageCommand)
                 // Have perms, create the builder and collect data
                 .flatMap(_bool -> messageCommand.setRequestData(new MessageInteractionContextBuilder(event))

--- a/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
@@ -1,19 +1,14 @@
 package net.exploitables.slashlib;
 
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
-import discord4j.core.event.domain.interaction.InteractionCreateEvent;
-import discord4j.core.event.domain.interaction.MessageInteractionEvent;
-import discord4j.core.event.domain.interaction.UserInteractionEvent;
+import discord4j.core.event.domain.interaction.*;
 import discord4j.core.object.entity.channel.GuildChannel;
-import discord4j.rest.util.PermissionSet;
 import net.exploitables.slashlib.commands.BaseCommand;
 import net.exploitables.slashlib.context.*;
 import reactor.core.publisher.Mono;
-import reactor.util.function.Tuple2;
 
 public class InteractionEventReceiverImpl implements InteractionEventReceiver {
-    private <E extends InteractionCreateEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
+    private <E extends DeferrableInteractionEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
         Mono<GuildChannel> gcMono = event.getInteraction()   // mono for getting the guild channel where the
             .getChannel()                                    // interaction occurred
             .ofType(GuildChannel.class);

--- a/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/InteractionEventReceiverImpl.java
@@ -7,6 +7,8 @@ import net.exploitables.slashlib.commands.BaseCommand;
 import net.exploitables.slashlib.context.*;
 import reactor.core.publisher.Mono;
 
+import java.util.Objects;
+
 public class InteractionEventReceiverImpl implements InteractionEventReceiver {
     private <E extends DeferrableInteractionEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
         Mono<GuildChannel> gcMono = event.getInteraction()   // mono for getting the guild channel where the
@@ -59,7 +61,8 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
             // Get the command, we use the helper method on the command Structure to get this as
             //  chat input commands care multi-level
             .flatMap(aci -> Mono.just(SlashLib.get().getCommandRegister().getCommandStructure().searchForChatCommand(aci))
-                // Check bot permissions in guild
+                .filter(pair -> pair.getKey() != null)  // Make sure the command is known to us (avoid NullPointerException)
+                // Check bot and user permissions in guild
                 .flatMap(pair -> checkPermissions(event, pair.getKey())
                     // Have perms, create the builder and collect data
                     .flatMap(_bool -> pair.getKey().setRequestData(new ChatInputInteractionContextBuilder(event, aci, pair.getValue()))
@@ -68,12 +71,13 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
                         .map(ChatInputInteractionContextBuilder::build)
                         // Call the command
                         .flatMap(context -> pair.getKey().executeChat(context)))));
-}
+    }
 
     @Override
     public Mono<UserInteractionContext> receiveUserInteractionEvent(UserInteractionEvent event) {
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(SlashLib.get().getCommandRegister().getCommandStructure().getUserCommands().get(event.getCommandName()))
+            .filter(Objects::nonNull)  // Make sure the command is known to us (avoid NullPointerException)
             // Check bot and user permissions in guild
             .flatMap(userCommand -> checkPermissions(event, userCommand)
                 // Have perms, create the builder and collect data
@@ -89,6 +93,7 @@ public class InteractionEventReceiverImpl implements InteractionEventReceiver {
     public Mono<MessageInteractionContext> receiveMessageInteractionEvent(MessageInteractionEvent event) {
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(SlashLib.get().getCommandRegister().getCommandStructure().getMessageCommands().get(event.getCommandName()))
+            .filter(Objects::nonNull)  // Make sure the command is known to us (avoid NullPointerException)
             // Check bot and user permissions in guild
             .flatMap(messageCommand -> checkPermissions(event, messageCommand)
                 // Have perms, create the builder and collect data

--- a/src/main/java/net/exploitables/slashlib/commands/BaseCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/BaseCommand.java
@@ -22,6 +22,8 @@ public abstract class BaseCommand {
     private boolean defaultPermission;
     // Permissions needed by the bot
     private PermissionSet botPermissions;
+    // Discord Permissions needed by the user who executes the command
+    private PermissionSet userDiscordPermissions;
     // If the command can be used in DMs
     private boolean usableInDMs;
 
@@ -35,6 +37,7 @@ public abstract class BaseCommand {
 
         this.defaultPermission = true;
         this.botPermissions = PermissionSet.none();
+        this.userDiscordPermissions = PermissionSet.none();
         this.usableInDMs = false;
     }
 
@@ -77,10 +80,20 @@ public abstract class BaseCommand {
         this.botPermissions = PermissionSet.of(permissions);
     }
 
+    /**
+     * Set the Discord permissions a user needs to execute this command.
+     *
+     * @param permissions a unique list of Discord permissions
+     */
+    protected void setUserDiscordPermissions(Permission... permissions) {
+        this.userDiscordPermissions = PermissionSet.of(permissions);
+    }
+
     public String getName() { return name; }
     public String getDescription() { return description; }
     public ApplicationCommand.Type getCommandType() { return commandType; }
     public boolean isDefaultPermission() { return defaultPermission; }
     public PermissionSet getBotPermissions() { return botPermissions; }
+    public PermissionSet getUserDiscordPermissions() { return userDiscordPermissions; }
     public boolean isUsableInDMs() { return usableInDMs; }
 }


### PR DESCRIPTION
Adds a new property for commands, "userDiscordPermissions" - basically a PermissionSet for Discord permissions users need to execute this command. E.g. A user should need Kick Members to run a command such as /kick. (Up to the bot's owner to set this, of course).
(Do note that I chose to write "user**Discord**Permissions" in order to avoid a naming clash with a possible application command permissions implementation in the future.)

Also, changed "InteractionCreateEvent" to "DeferrableInteractionEvent"  in InteractionEventReceiverImpl in order to account for Discord4J 3.2.1.
Finally, added a fix (.filter() on InteractionEventReceiverImpl methods) for if someone tries to execute a command the library doesn't know of (used to cause a NullPointerException).

Feel free to suggest any changes.