### PR TITLE
OptionBuilder Rework and AutoComplete Support

### DIFF
--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiver.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiver.java
@@ -20,5 +20,5 @@ public interface GenericEventReceiver<CI extends ChatContext, UI extends UserCon
     Mono<CI> receiveChatInputInteractionEvent(ChatInputInteractionEvent event);
     Mono<UI> receiveUserInteractionEvent(UserInteractionEvent event);
     Mono<MI> receiveMessageInteractionEvent(MessageInteractionEvent event);
-    Mono<Void> receiveAutocompleteEvent(ChatInputAutoCompleteEvent event);
+    Mono<Void> receiveAutoCompleteEvent(ChatInputAutoCompleteEvent event);
 }

--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiver.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiver.java
@@ -1,5 +1,6 @@
 package net.exploitables.slashlib;
 
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.event.domain.interaction.MessageInteractionEvent;
 import discord4j.core.event.domain.interaction.UserInteractionEvent;
@@ -19,4 +20,5 @@ public interface GenericEventReceiver<CI extends ChatContext, UI extends UserCon
     Mono<CI> receiveChatInputInteractionEvent(ChatInputInteractionEvent event);
     Mono<UI> receiveUserInteractionEvent(UserInteractionEvent event);
     Mono<MI> receiveMessageInteractionEvent(MessageInteractionEvent event);
+    Mono<Void> receiveAutocompleteEvent(ChatInputAutoCompleteEvent event);
 }

--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
@@ -184,7 +184,7 @@ public class GenericEventReceiverImpl<
             .flatMap(aci -> Mono.just(genericSlashLib.getCommandRegister().getCommandStructure().searchForChatCommand(aci))
                 // Check bot permissions in guild
                 .flatMap(pair -> checkPermissions(event, pair.getKey())
-                // Have perms, call the autocomplete method for the command
-                .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(new AutoCompleteContext(event, aci)))));
+                    // Have perms, call the autocomplete method for the command
+                    .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(new AutoCompleteContext(event, aci, pair.getValue())))));
     }
 }

--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
@@ -1,10 +1,7 @@
 package net.exploitables.slashlib;
 
 
-import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
-import discord4j.core.event.domain.interaction.DeferrableInteractionEvent;
-import discord4j.core.event.domain.interaction.MessageInteractionEvent;
-import discord4j.core.event.domain.interaction.UserInteractionEvent;
+import discord4j.core.event.domain.interaction.*;
 import discord4j.core.object.entity.channel.GuildChannel;
 import net.exploitables.slashlib.commands.BaseCommand;
 import net.exploitables.slashlib.context.*;
@@ -39,6 +36,22 @@ public class GenericEventReceiverImpl<
     }
 
     /**
+     * Base logic for checking permissions, needs to be this generic for {@link AutoCompleteInteractionEvent}
+     *
+     * @param event the event received for an interaction
+     * @param baseCommand the command related to the interaction
+     * @return a present and true boolean if permissions are valid, an empty Mono if permissions are missing
+     */
+    private <E extends InteractionCreateEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
+        return event.getInteraction()
+            .getChannel()
+            .ofType(GuildChannel.class)
+            .flatMap(gc -> gc.getEffectivePermissions(event.getClient().getSelfId()))
+            .map(perms -> perms.containsAll(baseCommand.getBotPermissions()))
+            .switchIfEmpty(Mono.just(false));
+    }
+
+    /**
      * Check that the bot has permissions to execute the called command. And that the command can be used in a
      *  {@link discord4j.core.object.entity.channel.PrivateChannel} if called from one.
      *
@@ -49,13 +62,8 @@ public class GenericEventReceiverImpl<
      * @param baseCommand the target command to execute
      * @return a present (and true) mono if command execution can continue, empty otherwise
      */
-    private <E extends DeferrableInteractionEvent, B extends BaseCommand> Mono<Boolean> checkPermissions(E event, B baseCommand) {
-        return event.getInteraction()
-            .getChannel()
-            .ofType(GuildChannel.class)
-            .flatMap(gc -> gc.getEffectivePermissions(event.getClient().getSelfId()))
-            .map(perms -> perms.containsAll(baseCommand.getBotPermissions()))
-            .switchIfEmpty(Mono.just(false))
+    private <E extends DeferrableInteractionEvent, B extends BaseCommand> Mono<Boolean> checkPermissionsAndReply(E event, B baseCommand) {
+        return checkPermissions(event, baseCommand)
             .filter(havePerms -> havePerms || baseCommand.isUsableInDMs())
             // No perms and not usable in DMs, send silent error message
             .switchIfEmpty(Mono.defer(() -> {
@@ -85,7 +93,7 @@ public class GenericEventReceiverImpl<
             //  chat input commands care multi-level
             .flatMap(aci -> Mono.just(genericSlashLib.getCommandRegister().getCommandStructure().searchForChatCommand(aci))
                 // Check bot permissions in guild
-                .flatMap(pair -> checkPermissions(event, pair.getKey())
+                .flatMap(pair -> checkPermissionsAndReply(event, pair.getKey())
                     // Have perms, create the builder and collect data
                     .flatMap(_bool -> {
                         try {
@@ -114,7 +122,7 @@ public class GenericEventReceiverImpl<
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(genericSlashLib.getCommandRegister().getCommandStructure().searchForUserCommand(event))
             // Check bot permissions in guild
-            .flatMap(userCommand -> checkPermissions(event, userCommand)
+            .flatMap(userCommand -> checkPermissionsAndReply(event, userCommand)
                 // Have perms, create the builder and collect data
                 .flatMap(_bool -> {
                     try {
@@ -142,7 +150,7 @@ public class GenericEventReceiverImpl<
         // Since User Interactions are only top level we can just get our command by the name
         return Mono.just(genericSlashLib.getCommandRegister().getCommandStructure().searchForMessageCommand(event))
             // Check bot permissions in guild
-            .flatMap(messageCommand -> checkPermissions(event, messageCommand)
+            .flatMap(messageCommand -> checkPermissionsAndReply(event, messageCommand)
                 // Have perms, create the builder and collect data
                 .flatMap(_bool -> {
                     try {
@@ -157,5 +165,26 @@ public class GenericEventReceiverImpl<
                 .ofType(genericSlashLib.getMessageContextClass())
                 // Call the command
                 .flatMap(messageCommand::executeMessage));
+    }
+
+    /**
+     * Receive an autocomplete event for a CHAT_INPUT command. The event is a convenience provided by D4J.
+     * Permissions are checked for the bot and calling user as well, the latter for security reasons if a command
+     *  is only restricted by a permissions check and not by Discord.
+     *
+     * @param event the event produced from a user entering options into a command
+     * @return an empty Mono on command event completion
+     */
+    @Override
+    public Mono<Void> receiveAutocompleteEvent(ChatInputAutoCompleteEvent event) {
+        // We need the command interaction to get the options
+        return Mono.justOrEmpty(event.getInteraction().getCommandInteraction())
+            // Get the command, we use the helper method on the command Structure to get this as
+            //  chat input commands care multi-level
+            .flatMap(aci -> Mono.just(genericSlashLib.getCommandRegister().getCommandStructure().searchForChatCommand(aci))
+                // Check bot permissions in guild
+                .flatMap(pair -> checkPermissions(event, pair.getKey())
+                // Have perms, call the autocomplete method for the command
+                .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(event))));
     }
 }

--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
@@ -185,6 +185,6 @@ public class GenericEventReceiverImpl<
                 // Check bot permissions in guild
                 .flatMap(pair -> checkPermissions(event, pair.getKey())
                 // Have perms, call the autocomplete method for the command
-                .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(event))));
+                .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(new AutoCompleteContext(event, aci)))));
     }
 }

--- a/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
+++ b/src/main/java/net/exploitables/slashlib/GenericEventReceiverImpl.java
@@ -176,7 +176,7 @@ public class GenericEventReceiverImpl<
      * @return an empty Mono on command event completion
      */
     @Override
-    public Mono<Void> receiveAutocompleteEvent(ChatInputAutoCompleteEvent event) {
+    public Mono<Void> receiveAutoCompleteEvent(ChatInputAutoCompleteEvent event) {
         // We need the command interaction to get the options
         return Mono.justOrEmpty(event.getInteraction().getCommandInteraction())
             // Get the command, we use the helper method on the command Structure to get this as
@@ -185,6 +185,6 @@ public class GenericEventReceiverImpl<
                 // Check bot permissions in guild
                 .flatMap(pair -> checkPermissions(event, pair.getKey())
                     // Have perms, call the autocomplete method for the command
-                    .flatMap(_boolean -> pair.getKey().receiveAutocompleteEvent(new AutoCompleteContext(event, aci, pair.getValue())))));
+                    .flatMap(_boolean -> pair.getKey().receiveAutoCompleteEvent(new AutoCompleteContext(event, aci, pair.getValue())))));
     }
 }

--- a/src/main/java/net/exploitables/slashlib/GenericSlashLib.java
+++ b/src/main/java/net/exploitables/slashlib/GenericSlashLib.java
@@ -134,7 +134,7 @@ public class GenericSlashLib<
         registerListener(eventDispatcher, ChatInputInteractionEvent.class,  getReceiver()::receiveChatInputInteractionEvent);
         registerListener(eventDispatcher, UserInteractionEvent.class,       getReceiver()::receiveUserInteractionEvent);
         registerListener(eventDispatcher, MessageInteractionEvent.class,    getReceiver()::receiveMessageInteractionEvent);
-        registerListener(eventDispatcher, ChatInputAutoCompleteEvent.class, getReceiver()::receiveAutocompleteEvent);
+        registerListener(eventDispatcher, ChatInputAutoCompleteEvent.class, getReceiver()::receiveAutoCompleteEvent);
     }
 
     /**

--- a/src/main/java/net/exploitables/slashlib/GenericSlashLib.java
+++ b/src/main/java/net/exploitables/slashlib/GenericSlashLib.java
@@ -3,6 +3,7 @@ package net.exploitables.slashlib;
 import discord4j.core.GatewayDiscordClient;
 import discord4j.core.event.EventDispatcher;
 import discord4j.core.event.domain.Event;
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.event.domain.interaction.ChatInputInteractionEvent;
 import discord4j.core.event.domain.interaction.MessageInteractionEvent;
 import discord4j.core.event.domain.interaction.UserInteractionEvent;
@@ -121,25 +122,19 @@ public class GenericSlashLib<
 
     /**
      * Register this instance with an {@link EventDispatcher} to handle:
-     * {@link ChatInputInteractionEvent}s   when any Chat Commands exist
-     * {@link UserInteractionEvent}s        when any User Commands exist
-     * {@link MessageInteractionEvent}s     when any Message Commands exist
+     * {@link ChatInputInteractionEvent}
+     * {@link UserInteractionEvent}
+     * {@link MessageInteractionEvent}
+     * {@link ChatInputAutoCompleteEvent}
      *
      * @param eventDispatcher the {@link EventDispatcher} to be used with the bots future {@link GatewayDiscordClient}
      */
     public void registerAsListener(EventDispatcher eventDispatcher) {
-        if (commandRegister.getCommandStructure().getGlobalChatCommands().size() > 0
-            || commandRegister.getCommandStructure().getGuildChatCommands().size() > 0) {
-            registerListener(eventDispatcher, ChatInputInteractionEvent.class, getReceiver()::receiveChatInputInteractionEvent);
-        }
-        if (commandRegister.getCommandStructure().getGlobalUserCommands().size() > 0
-            || commandRegister.getCommandStructure().getGuildUserCommands().size() > 0) {
-            registerListener(eventDispatcher, UserInteractionEvent.class, getReceiver()::receiveUserInteractionEvent);
-        }
-        if (commandRegister.getCommandStructure().getGlobalMessageCommands().size() > 0
-            || commandRegister.getCommandStructure().getGuildMessageCommands().size() > 0) {
-            registerListener(eventDispatcher, MessageInteractionEvent.class, getReceiver()::receiveMessageInteractionEvent);
-        }
+        // Should not be any notable performance overhead to register listeners for events that are never received
+        registerListener(eventDispatcher, ChatInputInteractionEvent.class,  getReceiver()::receiveChatInputInteractionEvent);
+        registerListener(eventDispatcher, UserInteractionEvent.class,       getReceiver()::receiveUserInteractionEvent);
+        registerListener(eventDispatcher, MessageInteractionEvent.class,    getReceiver()::receiveMessageInteractionEvent);
+        registerListener(eventDispatcher, ChatInputAutoCompleteEvent.class, getReceiver()::receiveAutocompleteEvent);
     }
 
     /**

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
@@ -1,6 +1,5 @@
 package net.exploitables.slashlib.commands.generic;
 
-import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
 import discord4j.core.object.command.ApplicationCommand;
 import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
@@ -8,6 +7,7 @@ import discord4j.discordjson.json.ApplicationCommandRequest;
 import discord4j.discordjson.json.ImmutableApplicationCommandOptionData;
 import discord4j.discordjson.json.ImmutableApplicationCommandRequest;
 import net.exploitables.slashlib.commands.BaseCommand;
+import net.exploitables.slashlib.context.AutoCompleteContext;
 import net.exploitables.slashlib.context.ChatContext;
 import net.exploitables.slashlib.context.ChatContextBuilder;
 import reactor.core.publisher.Mono;
@@ -57,10 +57,10 @@ public abstract class GenericChatCommand<IC extends ChatContext, IB extends Chat
         return contextBuilder;
     }
 
-    public Mono<Void> receiveAutocompleteEvent(AutoCompleteInteractionEvent event) {
+    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext context) {
         //noinspection OptionalGetWithoutIsPresent
         return Mono.error(new RuntimeException("No autocomplete implementation for command: " +
-                event.getInteraction().getCommandInteraction().get().getName()));
+                context.getEvent().getInteraction().getCommandInteraction().get().getName()));
     }
 
     /**

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
@@ -57,7 +57,7 @@ public abstract class GenericChatCommand<IC extends ChatContext, IB extends Chat
         return contextBuilder;
     }
 
-    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext context) {
+    public Mono<Void> receiveAutoCompleteEvent(AutoCompleteContext context) {
         //noinspection OptionalGetWithoutIsPresent
         return Mono.error(new RuntimeException("No autocomplete implementation for command: " +
                 context.getEvent().getInteraction().getCommandInteraction().get().getName()));

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericChatCommand.java
@@ -1,5 +1,6 @@
 package net.exploitables.slashlib.commands.generic;
 
+import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
 import discord4j.core.object.command.ApplicationCommand;
 import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
@@ -54,6 +55,12 @@ public abstract class GenericChatCommand<IC extends ChatContext, IB extends Chat
      */
     public IB setRequestData(IB contextBuilder) {
         return contextBuilder;
+    }
+
+    public Mono<Void> receiveAutocompleteEvent(AutoCompleteInteractionEvent event) {
+        //noinspection OptionalGetWithoutIsPresent
+        return Mono.error(new RuntimeException("No autocomplete implementation for command: " +
+                event.getInteraction().getCommandInteraction().get().getName()));
     }
 
     /**

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
@@ -1,9 +1,9 @@
 package net.exploitables.slashlib.commands.generic;
 
-import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
 import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
 import net.exploitables.slashlib.commands.MissingSubCommandException;
+import net.exploitables.slashlib.context.AutoCompleteContext;
 import net.exploitables.slashlib.context.ChatContext;
 import net.exploitables.slashlib.context.ChatContextBuilder;
 import reactor.core.publisher.Mono;
@@ -56,7 +56,7 @@ public abstract class GenericGroupCommand<IC extends ChatContext, IB extends Cha
      */
     @Override
     @Deprecated
-    public Mono<Void> receiveAutocompleteEvent(AutoCompleteInteractionEvent event) {
+    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext event) {
         throw new IllegalStateException("GenericGroupCommand receiveAutocompleteEvent was invoked.");
     }
 

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
@@ -1,5 +1,6 @@
 package net.exploitables.slashlib.commands.generic;
 
+import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
 import discord4j.core.object.command.ApplicationCommandOption;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
 import net.exploitables.slashlib.commands.MissingSubCommandException;
@@ -48,6 +49,15 @@ public abstract class GenericGroupCommand<IC extends ChatContext, IB extends Cha
     @Deprecated
     public IB setRequestData(IB builder) {
         throw new IllegalStateException("GenericGroupCommand setRequestData was invoked.");
+    }
+
+    /**
+     * @throws IllegalStateException GroupCommands cannot be called through Discord. Calling this is an error.
+     */
+    @Override
+    @Deprecated
+    public Mono<Void> receiveAutocompleteEvent(AutoCompleteInteractionEvent event) {
+        throw new IllegalStateException("GenericGroupCommand receiveAutocompleteEvent was invoked.");
     }
 
     /**

--- a/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
+++ b/src/main/java/net/exploitables/slashlib/commands/generic/GenericGroupCommand.java
@@ -56,7 +56,7 @@ public abstract class GenericGroupCommand<IC extends ChatContext, IB extends Cha
      */
     @Override
     @Deprecated
-    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext event) {
+    public Mono<Void> receiveAutoCompleteEvent(AutoCompleteContext event) {
         throw new IllegalStateException("GenericGroupCommand receiveAutocompleteEvent was invoked.");
     }
 

--- a/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
+++ b/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
@@ -2,8 +2,11 @@ package net.exploitables.slashlib.context;
 
 import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.object.command.ApplicationCommandInteraction;
+import discord4j.core.object.command.ApplicationCommandInteractionOption;
 import discord4j.core.object.entity.User;
 import net.exploitables.slashlib.utility.OptionsList;
+
+import java.util.List;
 
 /**
  * A simple class providing some autocomplete event context.
@@ -14,10 +17,10 @@ public class AutoCompleteContext {
     private final OptionsList optionsList;
     private final User user;
 
-    public AutoCompleteContext(ChatInputAutoCompleteEvent event, ApplicationCommandInteraction aci) {
+    public AutoCompleteContext(ChatInputAutoCompleteEvent event, ApplicationCommandInteraction aci, List<ApplicationCommandInteractionOption> options) {
         this.event = event;
         this.aci = aci;
-        this.optionsList = new OptionsList(aci.getOptions());
+        this.optionsList = new OptionsList(options);
         this.user = event.getInteraction().getUser();
     }
 

--- a/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
+++ b/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
@@ -1,0 +1,28 @@
+package net.exploitables.slashlib.context;
+
+import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
+import discord4j.core.object.command.ApplicationCommandInteraction;
+import discord4j.core.object.entity.User;
+import net.exploitables.slashlib.utility.OptionsList;
+
+/**
+ * A simple class providing some autocomplete event context.
+ */
+public class AutoCompleteContext {
+    private final AutoCompleteInteractionEvent event;
+    private final ApplicationCommandInteraction aci;
+    private final OptionsList optionsList;
+    private final User user;
+
+    public AutoCompleteContext(AutoCompleteInteractionEvent event, ApplicationCommandInteraction aci) {
+        this.event = event;
+        this.aci = aci;
+        this.optionsList = new OptionsList(aci.getOptions());
+        this.user = event.getInteraction().getUser();
+    }
+
+    public AutoCompleteInteractionEvent     getEvent()          { return event; }
+    public ApplicationCommandInteraction    getAci()            { return aci; }
+    public OptionsList                      getOptionsList()    { return optionsList; }
+    public User                             getUser()           { return user; }
+}

--- a/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
+++ b/src/main/java/net/exploitables/slashlib/context/AutoCompleteContext.java
@@ -1,6 +1,6 @@
 package net.exploitables.slashlib.context;
 
-import discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent;
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent;
 import discord4j.core.object.command.ApplicationCommandInteraction;
 import discord4j.core.object.entity.User;
 import net.exploitables.slashlib.utility.OptionsList;
@@ -9,20 +9,20 @@ import net.exploitables.slashlib.utility.OptionsList;
  * A simple class providing some autocomplete event context.
  */
 public class AutoCompleteContext {
-    private final AutoCompleteInteractionEvent event;
+    private final ChatInputAutoCompleteEvent event;
     private final ApplicationCommandInteraction aci;
     private final OptionsList optionsList;
     private final User user;
 
-    public AutoCompleteContext(AutoCompleteInteractionEvent event, ApplicationCommandInteraction aci) {
+    public AutoCompleteContext(ChatInputAutoCompleteEvent event, ApplicationCommandInteraction aci) {
         this.event = event;
         this.aci = aci;
         this.optionsList = new OptionsList(aci.getOptions());
         this.user = event.getInteraction().getUser();
     }
 
-    public AutoCompleteInteractionEvent     getEvent()          { return event; }
-    public ApplicationCommandInteraction    getAci()            { return aci; }
-    public OptionsList                      getOptionsList()    { return optionsList; }
-    public User                             getUser()           { return user; }
+    public ChatInputAutoCompleteEvent       getEvent()      { return event; }
+    public ApplicationCommandInteraction    getAci()        { return aci; }
+    public OptionsList                      getOptions()    { return optionsList; }
+    public User                             getUser()       { return user; }
 }

--- a/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
+++ b/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
@@ -1,6 +1,7 @@
 package net.exploitables.slashlib.utility;
 
 import discord4j.core.object.command.ApplicationCommandOption;
+import discord4j.core.object.entity.channel.Channel;
 import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
 import discord4j.discordjson.json.ImmutableApplicationCommandOptionData;
@@ -226,9 +227,11 @@ public class OptionBuilder {
 
     /**
      * Add a choice to this option using Discord4Js {@link ApplicationCommandOptionChoiceData}
+     * AutoComplete and Choices are mutually exclusive.
      *
      * @param choice the choice data to add
      * @return this instance
+     * @throws SlashLibOptionException when attempting to add a choice when autocomplete is enabled
      */
     public OptionBuilder addChoice(ApplicationCommandOptionChoiceData choice) {
         if (!(this.type.equals(ApplicationCommandOption.Type.STRING)
@@ -249,10 +252,12 @@ public class OptionBuilder {
 
     /**
      * Shortcut method to add a choice to this option using {@link ApplicationCommandOptionChoiceData#builder()}
+     * AutoComplete and Choices are mutually exclusive.
      *
      * @param name the display name of the value the user will see
      * @param value the actual value set for the option
      * @return this instance
+     * @throws SlashLibOptionException when attempting to add a choice when autocomplete is enabled
      */
     public OptionBuilder addChoice(String name, Object value) {
         this.addChoice(ApplicationCommandOptionChoiceData.builder().name(name).value(value).build());
@@ -281,6 +286,7 @@ public class OptionBuilder {
      *
      * @param minValue the minimum value the user can provide for this option
      * @return this instance
+     * @throws SlashLibOptionException when setting a min value for an option type that isn't INTEGER or NUMBER
      */
     public OptionBuilder setMinValue(double minValue) {
         if (!(this.type.equals(ApplicationCommandOption.Type.INTEGER) || this.type.equals(ApplicationCommandOption.Type.NUMBER))) {
@@ -295,6 +301,7 @@ public class OptionBuilder {
      *
      * @param maxValue the maximum value the user can provide for this option
      * @return this instance
+     * @throws SlashLibOptionException when setting a max value for an option type that isn't INTEGER or NUMBER
      */
     public OptionBuilder setMaxValue(double maxValue) {
         if (!(this.type.equals(ApplicationCommandOption.Type.INTEGER) || this.type.equals(ApplicationCommandOption.Type.NUMBER))) {
@@ -306,8 +313,10 @@ public class OptionBuilder {
 
     /**
      * Enable autocomplete events to be received when a user starts providing input for this option.
+     * AutoComplete and Choices are mutually exclusive.
      *
      * @return this instance
+     * @throws SlashLibOptionException when attempting to enable autocomplete when choices are set
      */
     public OptionBuilder setAutoCompleteEnabled() {
         if (this.choiceCount > 0) {

--- a/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
+++ b/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
@@ -292,7 +292,7 @@ public class OptionBuilder {
      *
      * @return this instance
      */
-    public OptionBuilder setAutocompleteEnabled() {
+    public OptionBuilder setAutoCompleteEnabled() {
         if (this.choiceCount > 0) {
             throw new SlashLibOptionException(this, "Cannot have autocomplete enabled and choices!");
         }

--- a/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
+++ b/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
@@ -260,6 +260,23 @@ public class OptionBuilder {
     }
 
     /**
+     * Restrict the types of channels that can be provided to this option if it is a channel type.
+     *
+     * @param channelTypes the types of channel to allow as a value for this option
+     * @return this instance
+     * @throws SlashLibOptionException when setting channel types for a non CHANNEL option
+     */
+    public OptionBuilder setChannelTypes(Channel.Type ... channelTypes) {
+        if (this.type.equals(ApplicationCommandOption.Type.CHANNEL)) {
+            throw new SlashLibOptionException(this, "Channel Types can only be set for CHANNEL options.");
+        }
+        for (Channel.Type type : channelTypes) {
+            this.option.addChannelType(type.getValue());
+        }
+        return this;
+    }
+
+    /**
      * Set the minimum value accepted for this option. Only valid on INTEGER and NUMBER types.
      *
      * @param minValue the minimum value the user can provide for this option

--- a/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
+++ b/src/main/java/net/exploitables/slashlib/utility/OptionBuilder.java
@@ -1,6 +1,7 @@
 package net.exploitables.slashlib.utility;
 
 import discord4j.core.object.command.ApplicationCommandOption;
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
 import discord4j.discordjson.json.ApplicationCommandOptionData;
 import discord4j.discordjson.json.ImmutableApplicationCommandOptionData;
 
@@ -8,214 +9,305 @@ import discord4j.discordjson.json.ImmutableApplicationCommandOptionData;
  * A utility class to build {@link ApplicationCommandOptionData} for commands in an appropriate
  *  fashion to be used with the {@link net.exploitables.slashlib.CommandRegister} updating process.
  *
+ * The option data is built as this class is built.
+ *
  * The most notorious "gotcha" as of D4J 3.2.0 SNAPSHOT (2021-08-27) is that required must be empty
  *  to be considered as false.
  */
+@SuppressWarnings("UnusedReturnValue")
 public class OptionBuilder {
-    private static ImmutableApplicationCommandOptionData.Builder buildOption(String name, String description, int type) {
-        return ApplicationCommandOptionData.builder()
-            .name(name)
-            .description(description)
-            .type(type);
+    final String name;
+    final String description;
+    final ApplicationCommandOption.Type type;
+
+    final ImmutableApplicationCommandOptionData.Builder option;
+
+    // Keep track of these to quickly reference them when needed.
+    private int choiceCount;
+    private boolean autocomplete;
+
+    public OptionBuilder(String name, String description, ApplicationCommandOption.Type type) {
+        this.name = name;
+        this.description = description;
+        this.type = type;
+
+        this.option = ApplicationCommandOptionData.builder().name(name).description(description).type(type.getValue());
+
+        this.choiceCount = 0;
+        this.autocomplete = false;
     }
 
     /**
-     * Create an optional string option.
+     * Shortcut to create an optional string option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional string
      */
-    public static ApplicationCommandOptionData optionalString(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.STRING.getValue())
-            .build();
+    public static OptionBuilder optionalString(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.STRING);
     }
 
     /**
-     * Create a required string option.
+     * Shortcut to create a required string option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required string
      */
-    public static ApplicationCommandOptionData requiredString(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.STRING.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredString(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.STRING).setIsRequired();
     }
 
     /**
-     * Create an optional integer option.
+     * Shortcut to create an optional integer option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional integer
      */
-    public static ApplicationCommandOptionData optionalInteger(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.INTEGER.getValue())
-            .build();
+    public static OptionBuilder optionalInteger(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.INTEGER);
     }
 
     /**
-     * Create a required integer option.
+     * Shortcut to create a required integer option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required integer
      */
-    public static ApplicationCommandOptionData requiredInteger(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.INTEGER.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredInteger(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.INTEGER).setIsRequired();
     }
 
     /**
-     * Create an optional boolean option.
+     * Shortcut to create an optional boolean option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional boolean
      */
-    public static ApplicationCommandOptionData optionalBoolean(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.BOOLEAN.getValue())
-            .build();
+    public static OptionBuilder optionalBoolean(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.BOOLEAN);
     }
 
     /**
-     * Create a required boolean option.
+     * Shortcut to create a required boolean option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required boolean
      */
-    public static ApplicationCommandOptionData requiredBoolean(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.BOOLEAN.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredBoolean(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.BOOLEAN).setIsRequired();
     }
 
     /**
-     * Create an optional user option.
+     * Shortcut to create an optional user option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional user
      */
-    public static ApplicationCommandOptionData optionalUser(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.USER.getValue())
-            .build();
+    public static OptionBuilder optionalUser(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.USER);
     }
 
     /**
-     * Create a required user option.
+     * Shortcut to create a required user option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required user
      */
-    public static ApplicationCommandOptionData requiredUser(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.USER.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredUser(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.USER).setIsRequired();
     }
 
     /**
-     * Create an optional channel option.
+     * Shortcut to create an optional channel option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional channel
      */
-    public static ApplicationCommandOptionData optionalChannel(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.CHANNEL.getValue())
-            .build();
+    public static OptionBuilder optionalChannel(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.CHANNEL);
     }
 
     /**
-     * Create a required channel option.
+     * Shortcut to create a required channel option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required channel
      */
-    public static ApplicationCommandOptionData requiredChannel(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.CHANNEL.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredChannel(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.CHANNEL).setIsRequired();
     }
 
     /**
-     * Create an optional role option.
+     * Shortcut to create an optional role option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional role
      */
-    public static ApplicationCommandOptionData optionalRole(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.ROLE.getValue())
-            .build();
+    public static OptionBuilder optionalRole(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.ROLE);
     }
 
     /**
-     * Create a required role option.
+     * Shortcut to create a required role option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required role
      */
-    public static ApplicationCommandOptionData requiredRole(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.ROLE.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredRole(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.ROLE).setIsRequired();
     }
 
     /**
-     * Create an optional mentionable option.
+     * Shortcut to create an optional mentionable option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional mentionable
      */
-    public static ApplicationCommandOptionData optionalMentionable(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.MENTIONABLE.getValue())
-            .build();
+    public static OptionBuilder optionalMentionable(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.MENTIONABLE);
     }
 
     /**
-     * Create a required mentionable option.
+     * Shortcut to create a required mentionable option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required mentionable
      */
-    public static ApplicationCommandOptionData requiredMentionable(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.MENTIONABLE.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredMentionable(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.MENTIONABLE).setIsRequired();
     }
 
     /**
-     * Create an optional number option.
+     * Shortcut to create an optional number option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to an optional number
      */
-    public static ApplicationCommandOptionData optionalNumber(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.NUMBER.getValue())
-            .build();
+    public static OptionBuilder optionalNumber(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.NUMBER);
     }
 
     /**
-     * Create a required number option.
+     * Shortcut to create a required number option.
      *
      * @param name name of the option
      * @param description description of the option
-     * @return a built {@link ApplicationCommandOptionData} which can be added to the options of a command
+     * @return a new {@link OptionBuilder} initialized to a required number
      */
-    public static ApplicationCommandOptionData requiredNumber(String name, String description) {
-        return buildOption(name, description, ApplicationCommandOption.Type.NUMBER.getValue())
-            .required(true)
-            .build();
+    public static OptionBuilder requiredNumber(String name, String description) {
+        return new OptionBuilder(name, description, ApplicationCommandOption.Type.NUMBER).setIsRequired();
+    }
+
+    /**
+     * State that this option must be provided by the user when calling the command.
+     * Implicitly called on any `requiredXXX(name, description)` method
+     *
+     * @return this instance
+     */
+    public OptionBuilder setIsRequired() {
+        this.option.required(true);
+        return this;
+    }
+
+    /**
+     * Add a choice to this option using Discord4Js {@link ApplicationCommandOptionChoiceData}
+     *
+     * @param choice the choice data to add
+     * @return this instance
+     */
+    public OptionBuilder addChoice(ApplicationCommandOptionChoiceData choice) {
+        if (!(this.type.equals(ApplicationCommandOption.Type.STRING)
+                || this.type.equals(ApplicationCommandOption.Type.INTEGER)
+                || this.type.equals(ApplicationCommandOption.Type.NUMBER))) {
+            throw new SlashLibOptionException(this, "Only STRING, INTEGER, and NUMBER option types can have choices.");
+        }
+        if (this.choiceCount >= 25) {
+            throw new SlashLibOptionException(this, "Exceeded number of choices an option can have! (25 max)");
+        }
+        if (this.autocomplete) {
+            throw new SlashLibOptionException(this, "Cannot have autocomplete enabled and choices.");
+        }
+        this.choiceCount++;
+        this.option.addChoice(choice);
+        return this;
+    }
+
+    /**
+     * Shortcut method to add a choice to this option using {@link ApplicationCommandOptionChoiceData#builder()}
+     *
+     * @param name the display name of the value the user will see
+     * @param value the actual value set for the option
+     * @return this instance
+     */
+    public OptionBuilder addChoice(String name, Object value) {
+        this.addChoice(ApplicationCommandOptionChoiceData.builder().name(name).value(value).build());
+        return this;
+    }
+
+    /**
+     * Set the minimum value accepted for this option. Only valid on INTEGER and NUMBER types.
+     *
+     * @param minValue the minimum value the user can provide for this option
+     * @return this instance
+     */
+    public OptionBuilder setMinValue(double minValue) {
+        if (!(this.type.equals(ApplicationCommandOption.Type.INTEGER) || this.type.equals(ApplicationCommandOption.Type.NUMBER))) {
+            throw new SlashLibOptionException(this, "Can only have a minimum value on an INTEGER or NUMBER option.");
+        }
+        this.option.minValue(minValue);
+        return this;
+    }
+
+    /**
+     * Set the maximum value accepted for this option. Only valid on INTEGER and NUMBER types.
+     *
+     * @param maxValue the maximum value the user can provide for this option
+     * @return this instance
+     */
+    public OptionBuilder setMaxValue(double maxValue) {
+        if (!(this.type.equals(ApplicationCommandOption.Type.INTEGER) || this.type.equals(ApplicationCommandOption.Type.NUMBER))) {
+            throw new SlashLibOptionException(this, "Can only have a maximum value on an INTEGER or NUMBER option.");
+        }
+        this.option.maxValue(maxValue);
+        return this;
+    }
+
+    /**
+     * Enable autocomplete events to be received when a user starts providing input for this option.
+     *
+     * @return this instance
+     */
+    public OptionBuilder setAutocompleteEnabled() {
+        if (this.choiceCount > 0) {
+            throw new SlashLibOptionException(this, "Cannot have autocomplete enabled and choices!");
+        }
+        this.autocomplete = true;
+        this.option.autocomplete(true);
+        return this;
+    }
+
+    /**
+     * Build a {@link ImmutableApplicationCommandOptionData} which can be provided to a callable command
+     *  with {@link net.exploitables.slashlib.commands.standard.ChatCommand#addOption(ApplicationCommandOptionData)}.
+     *
+     * @return a newly created {@link ImmutableApplicationCommandOptionData} based off the data in this instance
+     */
+    public ImmutableApplicationCommandOptionData build() {
+        return this.option.build();
     }
 }

--- a/src/main/java/net/exploitables/slashlib/utility/OptionsList.java
+++ b/src/main/java/net/exploitables/slashlib/utility/OptionsList.java
@@ -44,6 +44,16 @@ public class OptionsList {
     }
 
     /**
+     * Get the focused option, only present when related to an
+     * {@link discord4j.core.event.domain.interaction.AutoCompleteInteractionEvent}
+     *
+     * @return a present optional if a focused option is present
+     */
+    public Optional<ApplicationCommandInteractionOption> getFocusedOption() {
+        return this.options.stream().filter(ApplicationCommandInteractionOption::isFocused).findFirst();
+    }
+
+    /**
      * Get the value of the option with the specified name, for a String option type.
      *
      * @param name the name of the option to get

--- a/src/main/java/net/exploitables/slashlib/utility/SlashLibOptionException.java
+++ b/src/main/java/net/exploitables/slashlib/utility/SlashLibOptionException.java
@@ -1,0 +1,11 @@
+package net.exploitables.slashlib.utility;
+
+/**
+ * An exception thrown when an option is incorrectly configured with {@link OptionBuilder}
+ */
+public class SlashLibOptionException extends RuntimeException {
+    SlashLibOptionException(OptionBuilder optionBuilder, String message) {
+        super("Error while configuring OptionBuilder! " + optionBuilder.type.toString() + " Command, Name:"
+                + optionBuilder.name + ", Description:" + optionBuilder.description + ", Reason: " + message);
+    }
+}

--- a/src/test/java/net/exploitables/slashlib/example/basic/BasicExampleBot.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/BasicExampleBot.java
@@ -8,6 +8,7 @@ import net.exploitables.slashlib.SlashLibBuilder;
 import net.exploitables.slashlib.example.basic.interactions.chat.About;
 import net.exploitables.slashlib.example.basic.interactions.chat.Echo;
 import net.exploitables.slashlib.example.basic.interactions.chat.Ping;
+import net.exploitables.slashlib.example.basic.interactions.chat.choices.ChoicesGroup;
 import net.exploitables.slashlib.example.basic.interactions.chat.info.InfoGroup;
 import net.exploitables.slashlib.example.basic.interactions.message.MessageInfo;
 import net.exploitables.slashlib.example.basic.interactions.user.UserInfo;
@@ -44,6 +45,7 @@ public class BasicExampleBot {
             .addGlobalChatCommand(new Echo())
             .addGlobalChatCommand(new About())
             .addGlobalChatCommand(new InfoGroup())
+            .addGlobalChatCommand(new ChoicesGroup())
             // Add User commands
             .addGlobalUserCommand(new UserInfo())
             // Add Message commands

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/Echo.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/Echo.java
@@ -14,7 +14,7 @@ import reactor.core.publisher.Mono;
 public class Echo extends TopCommand {
     public Echo() {
         super("echo", "have a message echoed back to you");
-        addOption(OptionBuilder.requiredString("message", "the message to say back to you"));
+        addOption(OptionBuilder.requiredString("message", "the message to say back to you").build());
         // Set that this message can be used in DMs, this will skip all user/bot permissions checks
         setUsableInDMs();
     }

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesAnimals.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesAnimals.java
@@ -23,7 +23,7 @@ public class ChoicesAnimals extends SubCommand {
 
     public ChoicesAnimals() {
         super("animals", "a command with an option that tries to autocomplete for the user");
-        addOption(OptionBuilder.requiredString("animal", "the name of an animal").setAutocompleteEnabled().build());
+        addOption(OptionBuilder.requiredString("animal", "the name of an animal").setAutoCompleteEnabled().build());
 
         animals = new ArrayList<>();
         animals.addAll(Arrays.asList( // 5 entries per line, providing 30 which is 5 more than the limit for choices
@@ -44,7 +44,7 @@ public class ChoicesAnimals extends SubCommand {
     }
 
     @Override
-    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext event) {
+    public Mono<Void> receiveAutoCompleteEvent(AutoCompleteContext event) {
         // Getting a method reference from a map with the option name as key
         //  could do well for multiple autocomplete options.
         return Mono.justOrEmpty(event.getOptions().getFocusedOption())

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesAnimals.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesAnimals.java
@@ -1,0 +1,62 @@
+package net.exploitables.slashlib.example.basic.interactions.chat.choices;
+
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData;
+import net.exploitables.slashlib.commands.standard.SubCommand;
+import net.exploitables.slashlib.context.AutoCompleteContext;
+import net.exploitables.slashlib.context.ChatContext;
+import net.exploitables.slashlib.utility.OptionBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * An example command which demonstrates autocomplete event receiving.
+ *
+ * Since there are many ways to retrieve many kinds of data (particularly generated or persistent data),
+ *  the event is delivered directly to the command.
+ */
+public class ChoicesAnimals extends SubCommand {
+    private final List<String> animals;
+
+    public ChoicesAnimals() {
+        super("animals", "a command with an option that tries to autocomplete for the user");
+        addOption(OptionBuilder.requiredString("animal", "the name of an animal").setAutocompleteEnabled().build());
+
+        animals = new ArrayList<>();
+        animals.addAll(Arrays.asList( // 5 entries per line, providing 30 which is 5 more than the limit for choices
+            "aardvark", "buffalo", "elephant", "penguin", "turtle",
+            "tortoise", "dog", "cat", "bunny", "rabbit",
+            "ibex", "monkey", "alligator", "wolf", "badger",
+            "ant", "armadillo", "cockatoo", "bird", "snake",
+            "lion", "cheetah", "beetle", "pelican", "goose",
+            "possum", "fish", "squid", "ferret", "rhino"));
+    }
+
+    @Override
+    public Mono<ChatContext> executeChat(ChatContext context) {
+        // the animal option is required and will be present
+        //noinspection OptionalGetWithoutIsPresent
+        return context.getEvent().reply(context.getOptions().getString("animal").get())
+            .thenReturn(context);
+    }
+
+    @Override
+    public Mono<Void> receiveAutocompleteEvent(AutoCompleteContext event) {
+        // Getting a method reference from a map with the option name as key
+        //  could do well for multiple autocomplete options.
+        return Mono.justOrEmpty(event.getOptions().getFocusedOption())
+            // Not necessary in this example, but when multiple options
+            //  can autocomplete something must filter them.
+            .filter(option -> option.getName().equals("animal"))
+            .map(option -> animals.stream()
+                .filter(animal -> animal.toLowerCase().startsWith(event.getOptions().getString("animal").get()))
+                // This is weird, we need the interface not the implementing class.
+                .map(result -> (ApplicationCommandOptionChoiceData) ApplicationCommandOptionChoiceData.builder().name(result).value(result).build())
+                .collect(Collectors.toList()))
+            .flatMap(results -> event.getEvent().respondWithSuggestions(results));
+
+    }
+}

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesColors.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesColors.java
@@ -1,0 +1,36 @@
+package net.exploitables.slashlib.example.basic.interactions.chat.choices;
+
+import discord4j.core.spec.EmbedCreateSpec;
+import discord4j.core.spec.InteractionApplicationCommandCallbackSpec;
+import discord4j.rest.util.Color;
+import net.exploitables.slashlib.commands.standard.SubCommand;
+import net.exploitables.slashlib.context.ChatContext;
+import net.exploitables.slashlib.utility.OptionBuilder;
+import reactor.core.publisher.Mono;
+
+/**
+ * An example command which demonstrates using choices for option values.
+ */
+public class ChoicesColors extends SubCommand {
+    public ChoicesColors() {
+        super("colors", "a command with an option that accepts pre-defined colors as the value");
+        addOption(OptionBuilder.requiredInteger("color", "a selected color")
+                .addChoice("red", 0xFF0000)
+                .addChoice("green", 0x00FF00)
+                .addChoice("blue", 0x0000FF)
+            .build());
+    }
+
+    @Override
+    public Mono<ChatContext> executeChat(ChatContext context) {
+        // the color option is required and will be present
+        //noinspection OptionalGetWithoutIsPresent
+        return context.getEvent().reply(InteractionApplicationCommandCallbackSpec.builder()
+            .addEmbed(EmbedCreateSpec.builder()
+                .color(Color.of(Math.toIntExact(context.getOptions().getInteger("color").get())))
+                .description("Color Value: `" + context.getOptions().getInteger("color").get() + "`")
+                .build())
+            .build())
+            .thenReturn(context);
+    }
+}

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesGroup.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/choices/ChoicesGroup.java
@@ -1,0 +1,11 @@
+package net.exploitables.slashlib.example.basic.interactions.chat.choices;
+
+import net.exploitables.slashlib.commands.standard.TopGroupCommand;
+
+public class ChoicesGroup extends TopGroupCommand {
+    public ChoicesGroup() {
+        super("choices", "commands which offer choices and autocomplete for options");
+        addSubCommand(new ChoicesColors());
+        addSubCommand(new ChoicesAnimals());
+    }
+}

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/info/entity/InfoChannel.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/info/entity/InfoChannel.java
@@ -23,7 +23,7 @@ class InfoChannel extends SubCommand {
         // We add options the interaction needs here
         // We can use the OptionBuilder helper class,
         //  but creating the options with raw Discord4J objects will work too
-        addOption(OptionBuilder.optionalChannel("channel", "the channel to show info about"));
+        addOption(OptionBuilder.optionalChannel("channel", "the channel to show info about").build());
         // Since we respond with an embed, we need the EMBED_LINKS permission
         // The default handler will respond with a message about the missing permissions
         //  and not execute this interaction if missing.

--- a/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/info/entity/InfoRole.java
+++ b/src/test/java/net/exploitables/slashlib/example/basic/interactions/chat/info/entity/InfoRole.java
@@ -21,7 +21,7 @@ class InfoRole extends SubCommand {
         // We will require a role here unlike in the channel example
         // We require no data since we don't need the channel this interaction
         //  was called in under the event the option isn't provided.
-        addOption(OptionBuilder.requiredRole("role", "the role to show info about"));
+        addOption(OptionBuilder.requiredRole("role", "the role to show info about").build());
         // Since we respond with an embed, we need the EMBED_LINKS permission
         // The default handler will respond with a message about the missing permissions
         //  and not execute this interaction if missing.


### PR DESCRIPTION
__**Description:**__ <br />
`OptionBuilder` completely redone to support all new interaction properties such as:
- `choices`
- `channel_types`
- `min_value`
- `max_value`
- `autocomplete`

SlashLib updated to support AutoComplete events which are delivered to the command class.

__**Justification:**__ <br />
Support for Discord features.

__**Changes for End Users:**__ <br />
`OptionBuilder` is now following a more standard builder pattern. The same convenience methods are available but they will now need to be built with `.build()`.
`GenericEventReceiver` has a new interface method to receive autocomplete events.
`GenericChatCommand` has a default implementation for the autocomplete method which throws an exception, this must be overridden for commands which support autocomplete options.